### PR TITLE
Update handleReturnToTab

### DIFF
--- a/src/pages/Wise/index.tsx
+++ b/src/pages/Wise/index.tsx
@@ -155,11 +155,17 @@ const Wise: React.FC<WiseProps> = ({
     })
   };
 
-  const handleReturnToTab = async() => {
+  const handleReturnToTab = async () => {
     if (originalTabId) {
-      chrome.tabs.update(originalTabId, {
-        active: true,
+      chrome.tabs.update(originalTabId, { active: true }, (tab) => {
+        if (chrome.runtime.lastError) {
+          console.error("Failed to find original tab:", chrome.runtime.lastError.message);
+
+          chrome.tabs.create({ url: urlForAction });
+        }
       });
+    } else {
+      chrome.tabs.create({ url: urlForAction });
     }
   };
 
@@ -275,6 +281,22 @@ const Wise: React.FC<WiseProps> = ({
   /*
    * Helpers
    */
+
+  const urlForAction = useMemo(() => {
+    switch (action) {
+      case WiseAction.REGISTRATION:
+        return 'https://zkp2p.xyz/register';
+      
+        case WiseAction.DEPOSITOR_REGISTRATION:
+        return 'https://zkp2p.xyz/deposits';
+      
+        case WiseAction.TRANSFER:
+        return 'https://zkp2p.xyz/swap';
+      
+        default:
+        return 'https://zkp2p.xyz';
+    }
+  }, [action]);
 
   const actionSettings = useMemo(() => {
     const settingsObject = {


### PR DESCRIPTION
Button now checks if browser can return to original tab. If not, it opens up the page that the proof is used for.

- Currently does not differentiate between environments so the button will always go back to production client (zkp2p.xyz) vs clients for any other env (e.g. localhost:3000)

<img width="340" alt="Screenshot 2024-04-16 at 12 17 34 PM" src="https://github.com/zkp2p/zk-p2p-extension/assets/3453571/9c2faaac-dda1-4a72-a889-8315866428e6">
